### PR TITLE
feat: Add proper typeguards.

### DIFF
--- a/rustshed/__init__.py
+++ b/rustshed/__init__.py
@@ -4,6 +4,7 @@ from .panic import Panic
 from .result_shortcut import result_shortcut
 from .to_option import to_option
 from .to_result import to_io_result, to_result
+from .typeguards import is_err, is_null, is_ok, is_some
 
 __all__ = [
     "Option",
@@ -20,4 +21,8 @@ __all__ = [
     "Panic",
     "to_io_result",
     "IOResult",
+    "is_some",
+    "is_null",
+    "is_ok",
+    "is_err",
 ]

--- a/rustshed/option_result.py
+++ b/rustshed/option_result.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Callable, Generic, NoReturn, TypeGuard, TypeVar, cast, overload
+from typing import Any, Callable, Generic, NoReturn, TypeVar, cast, overload
 
 from .panic import Panic
 
@@ -60,9 +60,14 @@ class _BaseOption(ABC, Generic[T_co]):
     """
 
     @abstractmethod
-    def is_some(self) -> TypeGuard[Some[T_co]]:
+    def is_some(self) -> bool:
         """
         Returns true if the option is a Some value.
+
+        Note that this method does not return a TypeGuard.
+        This is impossible as per design of PEP-647 TypeGuards.
+
+        If you want to take advantage of a type guard, use `rustshed.is_some` instead.
         """
 
     @abstractmethod
@@ -73,9 +78,14 @@ class _BaseOption(ABC, Generic[T_co]):
         """
 
     @abstractmethod
-    def is_null(self) -> TypeGuard[NullType]:
+    def is_null(self) -> bool:
         """
         Returns true if the option is a Null value.
+
+        Note that this method does not return a TypeGuard.
+        This is impossible as per design of PEP-647 TypeGuards.
+
+        If you want to take advantage of a type guard, use `rustshed.is_null` instead.
         """
 
     @abstractmethod
@@ -272,13 +282,13 @@ class _BaseOption(ABC, Generic[T_co]):
 class Some(_BaseOption[T_co]):
     value: T_co
 
-    def is_some(self) -> TypeGuard[Some[T_co]]:
+    def is_some(self) -> bool:
         return True
 
     def is_some_and(self, f: Callable[[T_co], bool]) -> bool:
         return f(self.value)
 
-    def is_null(self) -> TypeGuard[NullType]:
+    def is_null(self) -> bool:
         return False
 
     def expect(self, msg: str) -> T_co:
@@ -429,13 +439,13 @@ class NullType(_BaseOption[Any]):
     def __str__(self) -> str:
         return "Null"
 
-    def is_some(self) -> TypeGuard[Some[Any]]:
+    def is_some(self) -> bool:
         return False
 
     def is_some_and(self, f: Callable[[Any], bool]) -> bool:
         return False
 
-    def is_null(self) -> TypeGuard[NullType]:
+    def is_null(self) -> bool:
         return True
 
     def expect(self, msg: str) -> NoReturn:
@@ -525,9 +535,14 @@ Null = NullType()
 
 class _BaseResult(ABC, Generic[T_co, E_co]):
     @abstractmethod
-    def is_ok(self) -> TypeGuard[Ok[T_co]]:
+    def is_ok(self) -> bool:
         """
         Returns true if the result is Ok.
+
+        Note that this method does not return a TypeGuard.
+        This is impossible as per design of PEP-647 TypeGuards.
+
+        If you want to take advantage of a type guard, use `rustshed.is_ok` instead.
         """
 
     @abstractmethod
@@ -538,9 +553,14 @@ class _BaseResult(ABC, Generic[T_co, E_co]):
         """
 
     @abstractmethod
-    def is_err(self) -> TypeGuard[Err[E_co]]:
+    def is_err(self) -> bool:
         """
         Returns true if the result is Err.
+
+        Note that this method does not return a TypeGuard.
+        This is impossible as per design of PEP-647 TypeGuards.
+
+        If you want to take advantage of a type guard, use `rustshed.is_err` instead.
         """
 
     @abstractmethod
@@ -741,13 +761,13 @@ class _BaseResult(ABC, Generic[T_co, E_co]):
 class Ok(_BaseResult[T_co, Any]):
     value: T_co
 
-    def is_ok(self) -> TypeGuard[Ok[T_co]]:
+    def is_ok(self) -> bool:
         return True
 
     def is_ok_and(self, f: Callable[[T_co], bool]) -> bool:
         return f(self.value)
 
-    def is_err(self) -> TypeGuard[Err[Any]]:
+    def is_err(self) -> bool:
         return False
 
     def is_err_and(self, f: Callable[[Any], bool]) -> bool:
@@ -845,13 +865,13 @@ class Ok(_BaseResult[T_co, Any]):
 class Err(_BaseResult[Any, E_co]):
     error: E_co
 
-    def is_ok(self) -> TypeGuard[Ok[Any]]:
+    def is_ok(self) -> bool:
         return False
 
     def is_ok_and(self, f: Callable[[Any], bool]) -> bool:
         return False
 
-    def is_err(self) -> TypeGuard[Err[E_co]]:
+    def is_err(self) -> bool:
         return True
 
     def is_err_and(self, f: Callable[[E_co], bool]) -> bool:

--- a/rustshed/typeguards.py
+++ b/rustshed/typeguards.py
@@ -1,0 +1,22 @@
+from typing import Any, TypeGuard, TypeVar
+
+from rustshed.option_result import Err, NullType, Ok, Option, Result, Some
+
+T = TypeVar("T")
+E = TypeVar("E")
+
+
+def is_some(opt: Option[T]) -> TypeGuard[Some[T]]:
+    return opt.is_some()
+
+
+def is_null(opt: Option[Any]) -> TypeGuard[NullType]:
+    return opt.is_null()
+
+
+def is_ok(res: Result[T, Any]) -> TypeGuard[Ok[T]]:
+    return res.is_ok()
+
+
+def is_err(res: Result[Any, E]) -> TypeGuard[Err[E]]:
+    return res.is_err()

--- a/tests/typeguards_test.py
+++ b/tests/typeguards_test.py
@@ -1,0 +1,61 @@
+from rustshed import (
+    Err,
+    Null,
+    NullType,
+    Ok,
+    Option,
+    Result,
+    Some,
+    is_err,
+    is_null,
+    is_ok,
+    is_some,
+)
+
+
+def test_is_some() -> None:
+    x: Option[int] = Some(5)
+
+    assert is_some(x) is True
+    assert is_null(x) is False
+
+    if is_some(x):
+        # if the type is not narrowed down correctly
+        # mypy would throw an error
+        _y: Some[int] = x
+
+
+def test_is_null() -> None:
+    x: Option[int] = Null
+
+    assert is_some(x) is False
+    assert is_null(x) is True
+
+    if is_null(x):
+        # if the type is not narrowed down correctly
+        # mypy would throw an error
+        _z: NullType = x
+
+
+def test_is_ok() -> None:
+    x: Result[int, str] = Ok(5)
+
+    assert is_ok(x) is True
+    assert is_err(x) is False
+
+    if is_ok(x):
+        # if the type is not narrowed down correctly
+        # mypy would throw an error
+        _y: Ok[int] = x
+
+
+def test_is_err() -> None:
+    x: Result[int, str] = Err("foo")
+
+    assert is_ok(x) is False
+    assert is_err(x) is True
+
+    if is_err(x):
+        # if the type is not narrowed down correctly
+        # mypy would throw an error
+        _z: Err[str] = x


### PR DESCRIPTION
As per TypeGuards design, there is no way to define TypeGuards
for methods. Only functions are allowed.
See https://github.com/microsoft/pyright/discussions/3125
and https://peps.python.org/pep-0647/.